### PR TITLE
Improve SEO for Capivari searches

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,8 +5,18 @@
   <title>GeoMAG - Soluções em Topografia e Georreferenciamento</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="A GeoMAG oferece soluções completas em topografia, georreferenciamento, mapeamento 3D e regularização fundiária para projetos de engenharia, construção e agronegócio.">
-  <meta name="keywords" content="topografia, georreferenciamento, agrimensura, mapeamento 3D, regularização fundiária, GeoMAG, engenharia, Capivari SP">
+  <meta name="description" content="Empresa de topografia em Capivari, São Paulo (SP). Levantamentos topográficos, georreferenciamento e mapeamento 3D para projetos de engenharia, construção civil e agronegócio.">
+  <meta name="keywords" content="topografia capivari sp, topografia capivari são paulo, topografia em capivari sp, topógrafo capivari sp, georreferenciamento capivari sp, agrimensura, mapeamento 3D, regularização fundiária, GeoMAG, engenharia">
+  <link rel="canonical" href="https://geomag.com.br/">
+  <meta property="og:locale" content="pt_BR">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="GeoMAG - Topografia em Capivari SP">
+  <meta property="og:description" content="Soluções em topografia e georreferenciamento em Capivari, São Paulo (SP).">
+  <meta property="og:url" content="https://geomag.com.br/">
+  <meta property="og:image" content="assets/images/hero-topo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="GeoMAG - Topografia em Capivari SP">
+  <meta name="twitter:description" content="Soluções em topografia e georreferenciamento em Capivari, São Paulo (SP).">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
   <style>
@@ -36,6 +46,23 @@
       padding: 0 15px;
     }
   </style>
+  <script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "ProfessionalService",
+      "name": "GeoMAG Engenharia e Topografia",
+      "url": "https://geomag.com.br/",
+      "image": "assets/images/hero-topo.png",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "Rua Lino Marino Petena, 270",
+        "addressLocality": "Capivari",
+        "addressRegion": "SP",
+        "addressCountry": "BR"
+      },
+      "description": "Serviços de topografia e georreferenciamento em Capivari, São Paulo (SP)"
+    }
+  </script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- revert hero heading and description to original text
- keep SEO meta tags targeting Capivari, SP with Open Graph and JSON-LD data
- update meta keywords and descriptions for Capivari, São Paulo (SP)

## Testing
- `npm test` *(fails: ng not found)*
- `npx ng test --watch=false` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce7848ac8323b9465eee73e277f4