### PR TITLE
fix: reset orphan card styles on mobile to prevent last card from bei…

### DIFF
--- a/src/app/components/services/services.component.scss
+++ b/src/app/components/services/services.component.scss
@@ -134,4 +134,10 @@
   .features-grid {
     grid-template-columns: 1fr;
   }
+
+  .feat-card:last-child:nth-child(2n - 1) {
+    grid-column: auto;
+    max-width: none;
+    margin-inline: 0;
+  }
 }


### PR DESCRIPTION
…ng narrow

The tablet orphan-handling rule (max-width: 50%, grid-column: 1/-1) was cascading into the mobile breakpoint, causing the last service card to render at half width. Reset those properties at <=640px.