### PR TITLE
feat: tech-panel icons, mobile fixes & client tooltips

### DIFF
--- a/src/app/components/clients/clients.component.html
+++ b/src/app/components/clients/clients.component.html
@@ -16,14 +16,25 @@
              [src]="c.logo"
              [alt]="c.name"
              class="clients-logo"
-             loading="lazy">
+             loading="lazy"
+             (mouseenter)="showTooltip($event, c.name)"
+             (mouseleave)="hideTooltip()">
         <img *ngFor="let c of clients"
              [src]="c.logo"
              [alt]="c.name"
              class="clients-logo"
              loading="lazy"
-             aria-hidden="true">
+             aria-hidden="true"
+             (mouseenter)="showTooltip($event, c.name)"
+             (mouseleave)="hideTooltip()">
       </div>
+    </div>
+
+    <div class="clients-tooltip"
+         [class.clients-tooltip--visible]="tooltipVisible"
+         [style.left.px]="tooltipX"
+         [style.top.px]="tooltipY">
+      {{ tooltipText }}
     </div>
   </div>
 </section>

--- a/src/app/components/clients/clients.component.scss
+++ b/src/app/components/clients/clients.component.scss
@@ -2,7 +2,7 @@
   background: var(--gradient-dark-panel);
   color: #e4eff5;
   position: relative;
-  overflow: hidden;
+  overflow: clip;
 
   &::before {
     content: '';
@@ -71,6 +71,30 @@
   &:hover {
     transform: scale(1.08);
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+  }
+}
+
+.clients-tooltip {
+  position: fixed;
+  z-index: 300;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(-100%);
+  background: var(--gradient-dark-panel);
+  color: #e4eff5;
+  font-family: var(--font-body);
+  font-size: var(--text-body-sm);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--r-md);
+  border: 1px solid rgba(74, 128, 164, 0.3);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity var(--dur-fast) ease;
+
+  &--visible {
+    opacity: 1;
   }
 }
 

--- a/src/app/components/clients/clients.component.scss
+++ b/src/app/components/clients/clients.component.scss
@@ -96,13 +96,14 @@
 
 @media (max-width: 640px) {
   .clients-track {
-    gap: var(--sp-8);
+    gap: var(--sp-10);
     animation-duration: 55s;
   }
 
   .clients-logo {
-    height: 32px;
-    max-width: 100px;
+    height: 48px;
+    max-width: 130px;
+    padding: var(--sp-2) var(--sp-3);
   }
 }
 

--- a/src/app/components/clients/clients.component.ts
+++ b/src/app/components/clients/clients.component.ts
@@ -15,6 +15,11 @@ interface Client {
   imports: [CommonModule, RevealDirective]
 })
 export class ClientsComponent {
+  tooltipText = '';
+  tooltipX = 0;
+  tooltipY = 0;
+  tooltipVisible = false;
+
   clients: Client[] = [
     { name: 'Armelin', logo: 'assets/images/clientes/armelin.png' },
     { name: 'Azul Empreendimentos', logo: 'assets/images/clientes/azul.png' },
@@ -38,4 +43,17 @@ export class ClientsComponent {
     { name: 'Zorzi', logo: 'assets/images/clientes/zorzi.webp' },
     { name: 'Zuin Empreendimentos', logo: 'assets/images/clientes/zuin.png' },
   ];
+
+  showTooltip(event: MouseEvent, name: string): void {
+    const el = event.target as HTMLElement;
+    const rect = el.getBoundingClientRect();
+    this.tooltipText = name;
+    this.tooltipX = rect.left + rect.width / 2;
+    this.tooltipY = rect.top - 8;
+    this.tooltipVisible = true;
+  }
+
+  hideTooltip(): void {
+    this.tooltipVisible = false;
+  }
 }

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -134,12 +134,11 @@
   .navbar__nav {
     display: none;
     position: fixed;
-    top: 0;
+    top: 64px;
     left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(245, 248, 250, 0.98);
-    backdrop-filter: blur(20px);
+    width: 100%;
+    height: calc(100vh - 64px);
+    background: #f5f8fa;
     flex-direction: column;
     align-items: center;
     justify-content: center;

--- a/src/app/components/tech-panel/tech-panel.component.html
+++ b/src/app/components/tech-panel/tech-panel.component.html
@@ -15,9 +15,7 @@
       <div class="tech-item" *ngFor="let t of technologies; let i = index"
            appReveal [revealDelay]="(i + 1) * 0.1">
         <div class="tech-item__icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24">
-            <path [attr.d]="t.iconPath" />
-          </svg>
+          <img [src]="t.icon" [alt]="t.name" />
         </div>
         <h3 class="tech-item__name">{{ t.name }}</h3>
         <p class="tech-item__desc">{{ t.description }}</p>

--- a/src/app/components/tech-panel/tech-panel.component.scss
+++ b/src/app/components/tech-panel/tech-panel.component.scss
@@ -72,13 +72,10 @@
   justify-content: center;
   margin: 0 auto var(--sp-4);
 
-  svg {
-    width: 20px;
-    height: 20px;
-    stroke: #6aa3c5;
-    fill: none;
-    stroke-width: 1.5;
-    stroke-linecap: round;
+  img {
+    width: 28px;
+    height: 28px;
+    object-fit: contain;
   }
 }
 

--- a/src/app/components/tech-panel/tech-panel.component.ts
+++ b/src/app/components/tech-panel/tech-panel.component.ts
@@ -14,17 +14,17 @@ export class TechPanelComponent {
     {
       name: 'GNSS/RTK',
       description: 'Posicionamento por satélite com precisão centimétrica em tempo real.',
-      iconPath: 'M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5'
+      icon: 'assets/images/services/rover.png'
     },
     {
       name: 'Estação Total',
       description: 'Medição angular e de distâncias com tecnologia robótica automatizada.',
-      iconPath: 'M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8zM12 9a3 3 0 100 6 3 3 0 000-6z'
+      icon: 'assets/images/services/estacao-total.png'
     },
     {
       name: 'Drones',
       description: 'Aerofotogrametria e mapeamento aéreo com câmeras de alta resolução.',
-      iconPath: 'M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z'
+      icon: 'assets/images/services/drone.png'
     },
   ];
 }


### PR DESCRIPTION
## Summary
- **Tech-panel icons**: replaced SVG icons with service PNG images for visual consistency
- - **Mobile nav fix**: fixed collapsed mobile menu being cut off and not showing all items
- - **Client logos mobile**: increased logo size on mobile for better visibility
- - **Client tooltips**: added styled tooltip on hover showing client name, matching the design system
## Commits
- `8279200` feat: replace tech-panel SVG icons with service PNG images
- - `00f4492` fix: mobile nav menu cut off and small client logos
- - `ce38e17` feat: add styled tooltip on client logo hover
## Test plan
- [ ] Verify tech-panel shows correct PNG icons for each equipment
- [ ] - [ ] Test mobile nav menu opens fully and shows all items
- [ ] - [ ] Check client logos are appropriately sized on mobile
- [ ] - [ ] Hover over client logos to confirm tooltip displays with correct styling