### PR TITLE
seo: fase 1 — corrigir URLs críticas para domínio definitivo

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://geomag.netlify.app/sitemap.xml
+Sitemap: https://www.geomagtopografia.com.br/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://geomag.netlify.app/</loc>
+    <loc>https://www.geomagtopografia.com.br/</loc>
     <lastmod>2026-03-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.geomagtopografia.com.br/</loc>
-    <lastmod>2026-03-15</lastmod>
+    <lastmod>2026-04-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,8 @@
     <meta name="geo.placename" content="Capivari" />
     <meta name="geo.position" content="-23.0058;-47.5072" />
     <meta name="ICBM" content="-23.0058, -47.5072" />
-    <link rel="canonical" href="https://geomag.netlify.app/" />
+    <link rel="canonical" href="https://www.geomagtopografia.com.br/" />
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
 
     <!-- Open Graph -->
     <meta property="og:locale" content="pt_BR" />
@@ -30,8 +31,11 @@
       property="og:description"
       content="Levantamentos topográficos, georreferenciamento e mapeamento 3D com tecnologia de ponta. Mais de 500 projetos entregues em SP."
     />
-    <meta property="og:url" content="https://geomag.netlify.app/" />
-    <meta property="og:image" content="https://geomag.netlify.app/assets/images/hero-topo-2.png" />
+    <meta property="og:url" content="https://www.geomagtopografia.com.br/" />
+    <meta
+      property="og:image"
+      content="https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-horizontal-subtitulo.png"
+    />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
@@ -47,7 +51,10 @@
       name="twitter:description"
       content="Levantamentos topográficos, georreferenciamento e mapeamento 3D com tecnologia de ponta."
     />
-    <meta name="twitter:image" content="https://geomag.netlify.app/assets/images/hero-topo-2.png" />
+    <meta
+      name="twitter:image"
+      content="https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-horizontal-subtitulo.png"
+    />
     <meta name="twitter:image:alt" content="GeoMAG Topografia e Projetos" />
 
     <link rel="icon" type="image/png" href="assets/images/logo-nova/globo.png" />
@@ -65,9 +72,9 @@
         "@context": "https://schema.org",
         "@type": "ProfessionalService",
         "name": "GeoMAG Topografia e Projetos",
-        "url": "https://geomag.netlify.app/",
-        "logo": "https://geomag.netlify.app/assets/images/logo-nova/logo-horizontal-subtitulo.png",
-        "image": "https://geomag.netlify.app/assets/images/hero-topo-2.png",
+        "url": "https://www.geomagtopografia.com.br/",
+        "logo": "https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-horizontal-subtitulo.png",
+        "image": "https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-horizontal-subtitulo.png",
         "description": "Empresa de topografia em Capivari, SP. Levantamentos topográficos, georreferenciamento, mapeamento 3D e regularização fundiária com tecnologia de ponta.",
         "telephone": "+55-19-98183-7219",
         "email": "cesar@geomag.live",
@@ -91,7 +98,7 @@
           },
           {
             "@type": "State",
-            "name": "Santa Catarina"
+            "name": "Mato Grosso do Sul"
           },
           {
             "@type": "State",
@@ -174,7 +181,7 @@
             "name": "Qual a área de atuação da GeoMAG?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "A GeoMAG atua em Capivari e região, atendendo projetos nos estados de São Paulo, Santa Catarina e Paraná, com mais de 500 projetos entregues."
+              "text": "A GeoMAG atua em Capivari e região, atendendo projetos nos estados de São Paulo, Mato Grosso do Sul e Paraná, com mais de 500 projetos entregues."
             }
           },
           {

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,7 @@
     <meta property="og:url" content="https://www.geomagtopografia.com.br/" />
     <meta
       property="og:image"
-      content="https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-horizontal-subtitulo.png"
+      content="https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-vertical-subtitulo.png"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -53,7 +53,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-horizontal-subtitulo.png"
+      content="https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-vertical-subtitulo.png"
     />
     <meta name="twitter:image:alt" content="GeoMAG Topografia e Projetos" />
 
@@ -73,8 +73,8 @@
         "@type": "ProfessionalService",
         "name": "GeoMAG Topografia e Projetos",
         "url": "https://www.geomagtopografia.com.br/",
-        "logo": "https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-horizontal-subtitulo.png",
-        "image": "https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-horizontal-subtitulo.png",
+        "logo": "https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-vertical-subtitulo.png",
+        "image": "https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-vertical-subtitulo.png",
         "description": "Empresa de topografia em Capivari, SP. Levantamentos topográficos, georreferenciamento, mapeamento 3D e regularização fundiária com tecnologia de ponta.",
         "telephone": "+55-19-98183-7219",
         "email": "cesar@geomag.live",


### PR DESCRIPTION
- Canonical, og:url, og:image, twitter:image e Schema.org atualizados de geomag.netlify.app para www.geomagtopografia.com.br
- og:image e twitter:image alterados para logo-horizontal-subtitulo.png
- Adicionado <link rel="sitemap"> no <head>
- sitemap.xml e robots.txt com URLs do domínio definitivo