### PR TITLE
fix: resolve broken unit tests and ts compilation errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18655,14 +18655,6 @@
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
-    },
-    "node_modules/zone.js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
-      "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     }
   }
 }

--- a/src/app/components/projetos/case-modal/case-modal.component.spec.ts
+++ b/src/app/components/projetos/case-modal/case-modal.component.spec.ts
@@ -12,6 +12,7 @@ describe('CaseModalComponent', () => {
     tag: 'Test Tag',
     title: 'Test Case',
     thumb: 'thumb.jpg',
+    alt: 'Alt single',
     gallery: [{ src: 'img1.jpg', alt: 'Imagem 1' }],
   };
 
@@ -20,6 +21,7 @@ describe('CaseModalComponent', () => {
     tag: 'Multi Tag',
     title: 'Multi Case',
     thumb: 'thumb.jpg',
+    alt: 'Alt multi',
     gallery: [
       { src: 'img1.jpg', alt: 'Imagem 1' },
       { src: 'img2.jpg', alt: 'Imagem 2' },

--- a/src/app/components/projetos/projetos.component.spec.ts
+++ b/src/app/components/projetos/projetos.component.spec.ts
@@ -25,13 +25,13 @@ describe('ProjetosComponent', () => {
   });
 
   it('openModal define activeModal', () => {
-    const c = { id: 'x', tag: 'T', title: 'T', thumb: 't.jpg', gallery: [] };
+    const c = { id: 'x', tag: 'T', title: 'T', thumb: 't.jpg', alt: 'A', gallery: [] };
     component.openModal(c);
     expect(component.activeModal()).toEqual(c);
   });
 
   it('closeModal limpa activeModal', () => {
-    const c = { id: 'x', tag: 'T', title: 'T', thumb: 't.jpg', gallery: [] };
+    const c = { id: 'x', tag: 'T', title: 'T', thumb: 't.jpg', alt: 'A', gallery: [] };
     component.openModal(c);
     component.closeModal();
     expect(component.activeModal()).toBeNull();

--- a/src/app/components/projetos/projetos.component.ts
+++ b/src/app/components/projetos/projetos.component.ts
@@ -1,9 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { RevealDirective } from '../../directives/reveal.directive';
 import { SceneHeroComponent } from './scenes/scene-hero/scene-hero.component';
 import { SceneLayerMorphComponent } from './scenes/scene-layer-morph/scene-layer-morph.component';
 import { SceneStripComponent } from './scenes/scene-strip/scene-strip.component';
-import { Scene, HeroScene, LayerMorphScene, StripScene } from './projetos.types';
+import { Scene, HeroScene, LayerMorphScene, StripScene, CaseCard } from './projetos.types';
 
 const IMG = (path: string) => `assets/images/projetos/${path}`;
 const VID = (path: string) => `assets/videos/projetos/${path}`;
@@ -85,21 +85,25 @@ const SCENES: Scene[] = [
         id: 'casa-branca',
         thumb: IMG('casa-branca-thumb.jpg'),
         alt: 'Pranchas técnicas georreferenciadas',
+        gallery: [],
       },
       {
         id: 'golinelli',
         thumb: IMG('golinelli-thumb.jpg'),
         alt: 'Prancha LEPAC — Parque Golinelli',
+        gallery: [],
       },
       {
         id: 'estrela-do-sul',
         thumb: IMG('estrela-do-sul-thumb.jpg'),
         alt: 'Projeto de loteamento',
+        gallery: [],
       },
       {
         id: 'terraplanagem',
         thumb: IMG('terraplanagem-01-thumb.jpg'),
         alt: 'Evolução de obra — terraplanagem',
+        gallery: [],
       },
     ],
   },
@@ -116,4 +120,14 @@ export class ProjetosComponent {
   readonly heroScene = SCENES.find((s): s is HeroScene => s.kind === 'hero');
   readonly morphScenes = SCENES.filter((s): s is LayerMorphScene => s.kind === 'layer-morph');
   readonly stripScene = SCENES.find((s): s is StripScene => s.kind === 'strip');
+
+  activeModal = signal<CaseCard | null>(null);
+
+  openModal(c: CaseCard) {
+    this.activeModal.set(c);
+  }
+
+  closeModal() {
+    this.activeModal.set(null);
+  }
 }

--- a/src/app/components/projetos/projetos.types.ts
+++ b/src/app/components/projetos/projetos.types.ts
@@ -21,6 +21,9 @@ export interface CaseCard {
   id: string;
   thumb: string;
   alt: string;
+  tag?: string;
+  title?: string;
+  gallery: GalleryItem[];
 }
 
 export interface HeroScene {

--- a/src/app/components/projetos/scenes/scene-layer-morph/scene-layer-morph.component.spec.ts
+++ b/src/app/components/projetos/scenes/scene-layer-morph/scene-layer-morph.component.spec.ts
@@ -1,13 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PLATFORM_ID } from '@angular/core';
 import { SceneLayerMorphComponent } from './scene-layer-morph.component';
-import { ProjectMeta, Layer } from '../../projetos.types';
+import { Layer } from '../../projetos.types';
 
 describe('SceneLayerMorphComponent', () => {
   let fixture: ComponentFixture<SceneLayerMorphComponent>;
   let component: SceneLayerMorphComponent;
 
-  const testProject: ProjectMeta = { tag: 'Test', title: 'Test Project', specs: [] };
   const testLayers: Layer[] = [
     { src: 'a.png', label: 'Orto', desc: 'Descricao A' },
     { src: 'b.png', label: 'DEM', desc: 'Descricao B' },
@@ -22,7 +21,6 @@ describe('SceneLayerMorphComponent', () => {
 
     fixture = TestBed.createComponent(SceneLayerMorphComponent);
     component = fixture.componentInstance;
-    component.project = testProject;
     component.layers = testLayers;
     fixture.detectChanges();
   });


### PR DESCRIPTION
Fixes broken Karma unit tests across the `projetos` components. Adjusted the type structures specifically the `CaseCard` to include fields expected by the components and fixed broken mock data in specs accordingly. Also re-added `activeModal` signal to the `ProjetosComponent`. All tests now pass correctly.

---
*PR created automatically by Jules for task [14091096860607233685](https://jules.google.com/task/14091096860607233685) started by @GuiFranca*