### PR TITLE
feat: adicionar secao de FAQ visivel na home

### DIFF
--- a/src/app/components/faq/faq.component.html
+++ b/src/app/components/faq/faq.component.html
@@ -1,0 +1,29 @@
+<section id="faq" class="faq-section" aria-labelledby="faq-title">
+  <div class="container">
+    <header class="faq-header" appReveal>
+      <div class="s-label">Dúvidas Frequentes</div>
+      <h2 id="faq-title" class="s-title">Perguntas <span class="grad-text">frequentes</span></h2>
+    </header>
+
+    <div class="faq-list" appReveal>
+      @for (item of faqs; track item.question) {
+        <details class="faq-item">
+          <summary class="faq-item__question">
+            {{ item.question }}
+            <svg
+              class="faq-item__chevron"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              aria-hidden="true"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </summary>
+          <p class="faq-item__answer">{{ item.answer }}</p>
+        </details>
+      }
+    </div>
+  </div>
+</section>

--- a/src/app/components/faq/faq.component.scss
+++ b/src/app/components/faq/faq.component.scss
@@ -1,0 +1,68 @@
+.faq-section {
+  padding: var(--section-pad, 5rem 0);
+  background: var(--color-bg-surface);
+}
+
+.faq-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.faq-list {
+  max-width: 760px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.faq-item {
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+
+  &[open] {
+    border-color: var(--color-border-mid);
+
+    .faq-item__chevron {
+      transform: rotate(180deg);
+    }
+  }
+
+  &__question {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.1rem 1.4rem;
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    list-style: none;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &:hover {
+      color: var(--accent-dark);
+    }
+  }
+
+  &__chevron {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    color: var(--accent);
+    transition: transform 0.25s ease;
+  }
+
+  &__answer {
+    padding: 0 1.4rem 1.2rem;
+    margin: 0;
+    color: var(--color-text-secondary);
+    line-height: 1.65;
+  }
+}

--- a/src/app/components/faq/faq.component.ts
+++ b/src/app/components/faq/faq.component.ts
@@ -1,0 +1,56 @@
+import { Component } from '@angular/core';
+
+import { RevealDirective } from '../../directives/reveal.directive';
+
+interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+/**
+ * FAQ visível na página.
+ * IMPORTANTE: estas perguntas/respostas devem espelhar o schema FAQPage
+ * do index.html — o Google exige que dados estruturados correspondam
+ * a conteúdo visível na página.
+ */
+@Component({
+  selector: 'app-faq',
+  standalone: true,
+  imports: [RevealDirective],
+  templateUrl: './faq.component.html',
+  styleUrls: ['./faq.component.scss'],
+})
+export class FaqComponent {
+  faqs: FaqItem[] = [
+    {
+      question: 'Quais serviços de topografia a GeoMAG oferece?',
+      answer:
+        'Levantamentos topográficos, georreferenciamento de imóveis (INCRA), aerofotogrametria com drones, mapeamento 3D, regularização fundiária, topografia para obras, desmembramento de imóveis, terraplanagem e cadastro ambiental rural (CAR).',
+    },
+    {
+      question: 'Quanto custa um serviço de topografia?',
+      answer:
+        'O valor depende do tamanho da área, do tipo de terreno e do produto final necessário (planta, memorial, certificação). O orçamento é gratuito e sem compromisso: envie a localização e a finalidade pelo WhatsApp e retornamos com o valor e o prazo.',
+    },
+    {
+      question: 'Quanto tempo leva um levantamento topográfico?',
+      answer:
+        'A maioria dos levantamentos residenciais e rurais é concluída em poucos dias entre o trabalho de campo e a entrega dos produtos. Projetos maiores, como loteamentos e georreferenciamento com certificação no INCRA, têm prazos específicos informados no orçamento.',
+    },
+    {
+      question: 'O georreferenciamento é obrigatório?',
+      answer:
+        'Sim, para imóveis rurais. A Lei 10.267/01 exige o georreferenciamento certificado pelo INCRA em transferências, desmembramentos e retificações de área, com prazos que variam conforme o tamanho da propriedade. A GeoMAG cuida de todo o processo, do levantamento à certificação.',
+    },
+    {
+      question: 'Qual a área de atuação da GeoMAG?',
+      answer:
+        'Atendemos Capivari e região, com projetos executados nos estados de São Paulo, Mato Grosso do Sul e Paraná. São mais de 500 projetos entregues.',
+    },
+    {
+      question: 'Quais tecnologias a GeoMAG utiliza?',
+      answer:
+        'GNSS/RTK com precisão centimétrica, estação total e drones com câmeras de alta resolução para aerofotogrametria, ortomosaicos, modelos digitais de elevação e mapeamento 3D.',
+    },
+  ];
+}

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -7,6 +7,7 @@
   <app-tech-panel></app-tech-panel>
   <app-projetos></app-projetos>
   <app-clients></app-clients>
+  <app-faq></app-faq>
   <app-cta></app-cta>
 </main>
 

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -3,6 +3,7 @@ import { HeroComponent } from '../hero/hero.component';
 import { ServicesComponent } from '../services/services.component';
 import { ClientsComponent } from '../clients/clients.component';
 import { TechPanelComponent } from '../tech-panel/tech-panel.component';
+import { FaqComponent } from '../faq/faq.component';
 import { CtaComponent } from '../cta/cta.component';
 import { ProjetosComponent } from '../projetos/projetos.component';
 import { environment } from '../../../environments/environment';
@@ -19,6 +20,7 @@ import { trackWhatsAppClick } from '../../shared/analytics';
     ClientsComponent,
     TechPanelComponent,
     CtaComponent,
+    FaqComponent,
     ProjetosComponent,
   ],
 })

--- a/src/index.html
+++ b/src/index.html
@@ -192,6 +192,29 @@
               "text": "Utilizamos GNSS/RTK com precisão centimétrica, estação total robótica e drones com câmeras de alta resolução para aerofotogrametria e mapeamento aéreo."
             }
           },
+          {
+            "@type": "Question",
+            "name": "Quanto custa um serviço de topografia?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "O valor depende do tamanho da área, do tipo de terreno e do produto final necessário. O orçamento é gratuito e sem compromisso: envie a localização e a finalidade pelo WhatsApp e retornamos com o valor e o prazo."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Quanto tempo leva um levantamento topográfico?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "A maioria dos levantamentos residenciais e rurais é concluída em poucos dias entre o trabalho de campo e a entrega dos produtos. Projetos maiores, como loteamentos e georreferenciamento com certificação no INCRA, têm prazos específicos informados no orçamento."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "O georreferenciamento é obrigatório?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Sim, para imóveis rurais. A Lei 10.267/01 exige o georreferenciamento certificado pelo INCRA em transferências, desmembramentos e retificações de área, com prazos que variam conforme o tamanho da propriedade."
+            }
           }
         ]
       }


### PR DESCRIPTION
## Resumo

Extraído do #22 a pedido — reintroduz a seção de FAQ separadamente para revisão isolada.

- Novo `FaqComponent` (accordion `<details>`, acessível, prerenderiza sem JS) integrado na home logo após `app-clients`.
- Schema `FAQPage` no `src/index.html` estendido com 3 perguntas novas (preço, prazo, obrigatoriedade do georreferenciamento) para espelhar o conteúdo visível — o Google exige que dados estruturados correspondam a conteúdo na página.

**Base**: `feat/ssg-seo-performance` (#22) — este PR depende dele e só deve ser mergeado depois. O diff mostra apenas as mudanças de FAQ.

## Test plan

- [x] `npm run build` → `Prerendered 1 static route.`
- [x] `npm run lint` → sem erros
- [ ] Conferir visualmente o accordion (abrir/fechar, teclado, leitor de tela)
- [ ] Rich results test após deploy para validar `FAQPage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)