### PR TITLE
fix(clients): corrigir salto no loop do carrossel de logos

### DIFF
--- a/src/app/components/clients/clients.component.html
+++ b/src/app/components/clients/clients.component.html
@@ -12,27 +12,28 @@
 
     <div class="clients-marquee" appReveal [revealDelay]="0.2">
       <div class="clients-track">
-        @for (c of clients; track c) {
-          <img
-            [src]="c.logo"
-            [alt]="c.name"
-            class="clients-logo"
-            loading="lazy"
-            (mouseenter)="showTooltip($event, c.name)"
-            (mouseleave)="hideTooltip()"
-          />
-        }
-        @for (c of clients; track c) {
-          <img
-            [src]="c.logo"
-            [alt]="c.name"
-            class="clients-logo"
-            loading="lazy"
-            aria-hidden="true"
-            (mouseenter)="showTooltip($event, c.name)"
-            (mouseleave)="hideTooltip()"
-          />
-        }
+        <div class="clients-group">
+          @for (c of clients; track c) {
+            <img
+              [src]="c.logo"
+              [alt]="c.name"
+              class="clients-logo"
+              (mouseenter)="showTooltip($event, c.name)"
+              (mouseleave)="hideTooltip()"
+            />
+          }
+        </div>
+        <div class="clients-group" aria-hidden="true">
+          @for (c of clients; track c) {
+            <img
+              [src]="c.logo"
+              [alt]="c.name"
+              class="clients-logo"
+              (mouseenter)="showTooltip($event, c.name)"
+              (mouseleave)="hideTooltip()"
+            />
+          }
+        </div>
       </div>
     </div>
 

--- a/src/app/components/clients/clients.component.scss
+++ b/src/app/components/clients/clients.component.scss
@@ -46,14 +46,22 @@
 
 .clients-track {
   display: flex;
-  align-items: center;
-  gap: var(--sp-16);
   width: max-content;
   animation: marquee 45s linear infinite;
+  will-change: transform;
 
   &:hover {
     animation-play-state: paused;
   }
+}
+
+// padding-right igual ao gap: cada grupo ocupa exatamente 50% do track,
+// entao translateX(-50%) alinha pixel-perfect com o inicio do segundo grupo
+.clients-group {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-16);
+  padding-right: var(--sp-16);
 }
 
 .clients-logo {
@@ -109,8 +117,9 @@
 }
 
 @media (max-width: 1024px) {
-  .clients-track {
+  .clients-group {
     gap: var(--sp-12);
+    padding-right: var(--sp-12);
   }
 
   .clients-logo {
@@ -121,8 +130,12 @@
 
 @media (max-width: 640px) {
   .clients-track {
-    gap: var(--sp-10);
     animation-duration: 55s;
+  }
+
+  .clients-group {
+    gap: var(--sp-10);
+    padding-right: var(--sp-10);
   }
 
   .clients-logo {
@@ -135,9 +148,17 @@
 @media (prefers-reduced-motion: reduce) {
   .clients-track {
     animation: none;
+    width: auto;
+  }
+
+  .clients-group {
     flex-wrap: wrap;
     justify-content: center;
-    width: auto;
+    padding-right: 0;
+
+    &[aria-hidden='true'] {
+      display: none;
+    }
   }
 
   .clients-marquee {


### PR DESCRIPTION
## O que mudou

O carrossel de clientes travava e reiniciava a cada ciclo, tanto no desktop quanto no mobile, em vez de fazer um loop infinito fluido.

- Os logos agora ficam em dois `.clients-group` identicos (o segundo com `aria-hidden`); cada grupo tem `padding-right` igual ao `gap`, entao cada grupo ocupa exatamente 50% do track e o `translateX(-50%)` alinha pixel a pixel com o inicio da segunda copia.
- Removido `loading=lazy` dos logos — o browser baixa apenas os 21 arquivos unicos (a copia vem do cache).
- Media queries (1024px/640px) ajustados para o gap/padding do grupo.
- `prefers-reduced-motion` agora oculta o grupo duplicado (antes a grade estatica mostrava os 42 logos repetidos).
- `will-change: transform` no track para suavidade.

## Por que

Duas causas raiz, confirmadas com medicao no DOM:

1. **Costura desalinhada em 32px**: o track era um unico flex com `gap: 64px` e 42 itens, gerando 41 espacamentos — falta o espacamento entre o fim e o recomeco. `translateX(-50%)` parava meio gap (32px) antes do ponto onde a segunda copia comeca, causando um salto visivel a cada ciclo.
2. **Lazy loading em marquee**: 0/42 imagens carregadas com a secao fora da tela; logos clipados pelo `overflow: hidden` so carregavam quando a animacao os trazia a area visivel, mudando a largura do track no meio da animacao (que e percentual) e causando solavancos.

## Verificacao

No dev server, desktop (1280px) e mobile (375px):

- Descompasso da costura: **32.0px antes → 0.00px depois**, nos dois viewports.
- Prova do frame de wrap: pausando a animacao 1ms antes do fim e comparando com o frame inicial, o logo visivel se move 0.053px — exatamente o deslocamento esperado de 1ms de animacao (0.054px). O wrap e imperceptivel.
- 42/42 imagens carregadas antes da animacao; sem erros de console; prettier ok.

## Nota para o reviewer

O branch se chama `fix/preview-link` mas contem apenas a correcao do carrossel — o nome ficou do contexto anterior da sessao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)