### PR TITLE
fix(seo): corrigir dimensoes do og:image e JSON-LD do FAQPage

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,8 +36,8 @@
       property="og:image"
       content="https://www.geomagtopografia.com.br/assets/images/logo-nova/logo-vertical-subtitulo.png"
     />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image:width" content="2212" />
+    <meta property="og:image:height" content="1172" />
     <meta property="og:image:type" content="image/png" />
     <meta
       property="og:image:alt"
@@ -191,7 +191,6 @@
               "@type": "Answer",
               "text": "Utilizamos GNSS/RTK com precisão centimétrica, estação total robótica e drones com câmeras de alta resolução para aerofotogrametria e mapeamento aéreo."
             }
-          },
           }
         ]
       }


### PR DESCRIPTION
## O que mudou

- `og:image:width`/`og:image:height` declaravam 1200x630, mas a imagem real (`logo-vertical-subtitulo.png`) tem **2212x1172** — as tags agora refletem as dimensoes reais do arquivo.
- Removida chave `}` extra que tornava o JSON-LD do `FAQPage` **invalido em producao** (confirmado com parse do HTML servido), o que inviabilizava os rich results de FAQ no Google. Ambos os blocos JSON-LD agora parseiam sem erro (validado no browser).

## Por que

Investigacao do bug de link preview do WhatsApp. O dominio principal passa em todos os requisitos do crawler (og tags nos primeiros 2KB, imagem PNG 134KB com 200 OK, robots.txt liberado, redirects normais) — a causa provavel do preview ausente e cache do aparelho apos janela de deploy, a validar com `?v=2`. Estas correcoes eliminam as unicas imperfeicoes reais encontradas nos metadados.

## Nota para o reviewer

Este commit estava no branch do PR #24, mas o merge foi concluido um instante antes do push — por isso ficou de fora do main e vem neste PR separado. Alerta a parte: `geomag.live` esta estacionado na Hostinger (nao gera preview); correcao e via DNS, fora deste repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)